### PR TITLE
Fix crash on `swift build`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
     	.package(url: "https://github.com/SlackKit/SKCore", .upToNextMinor(from: "4.1.0")),
     	.package(url: "https://github.com/SlackKit/SKWebAPI", .upToNextMinor(from: "4.1.0")),
-        .package(url: "https://github.com/httpswift/swifter.git", .branch("stable"))
+        .package(url: "https://github.com/httpswift/swifter.git", .upToNextMinor(from: "1.4.1"))
     ],
     targets: [
     	.target(name: "SKServer",


### PR DESCRIPTION
Currently getting this error when building using `swift build`:
```
error: the package PackageReference(identity: "skserver", name: nil, path: "https://github.com/SlackKit/SKServer", isLocal: false) @ 4.1.1 contains revisioned dependencies:
    PackageReference(identity: "swifter", name: nil, path: "https://github.com/httpswift/swifter.git", isLocal: false) @ stable
``` Did some research and it's related to specifying a branch instead of a version number